### PR TITLE
Improve compression reliability and configurability for Laravel 11/12

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,34 @@ protected $middleware = [
 
 
 > [!PS]
-> To see the package working, the application env should be `APP_ENV=production` and the `APP_DEBUG=false`
+> To see the package working in production-like mode, use `APP_ENV=production` (double-check typos) and `APP_DEBUG=false`.
+
+### Important for Laravel v11+ / v12
+
+If compression does not apply after changing environment/config values, clear cached config:
+
+```bash
+php artisan optimize:clear
+```
+
+When testing locally you can force compression:
+
+```env
+GZIP_FORCE=true
+```
 
 
 That's it! Now your responses will be gzipped.
+
+## Troubleshooting
+
+If you still don't see `Content-Encoding: gzip` or `Content-Encoding: br`, check:
+
+1. The request includes `Accept-Encoding: gzip` (or `br`).
+2. Response content is larger than `GZIP_MIN_LENGTH` (default is `256`).
+3. Route/path is not excluded by `excluded_paths`.
+4. MIME type is compressible.
+5. Config cache is cleared (`php artisan optimize:clear`) after env changes.
 
 ## Benchmark
 

--- a/config/laravel-gzip.php
+++ b/config/laravel-gzip.php
@@ -24,7 +24,7 @@ return [
     | - 9: Slowest, best compression
     |
     */
-    'level' => env('GZIP_LEVEL', 5),
+    'level' => env('GZIP_LEVEL', 6),
 
     /*
     |--------------------------------------------------------------------------
@@ -45,7 +45,7 @@ return [
     | Small responses don't benefit from compression.
     |
     */
-    'minimum_content_length' => env('GZIP_MIN_LENGTH', 1024),
+    'minimum_content_length' => env('GZIP_MIN_LENGTH', 256),
 
     /*
     |--------------------------------------------------------------------------
@@ -76,7 +76,7 @@ return [
     | Skip compression in local development environment.
     |
     */
-    'skip_local' => env('GZIP_SKIP_LOCAL', true),
+    'skip_local' => env('GZIP_SKIP_LOCAL', false),
 
 
     /*
@@ -88,6 +88,17 @@ return [
     |
     */
     'skip_testing' => env('GZIP_SKIP_TESTING', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Force Compression
+    |--------------------------------------------------------------------------
+    |
+    | Force compression even if current environment matches skip_local/testing.
+    | Useful for local debugging and checking headers in non-production setups.
+    |
+    */
+    'force' => env('GZIP_FORCE', false),
 
     /*
     |--------------------------------------------------------------------------
@@ -169,6 +180,18 @@ return [
         'image/svg+xml',
         'font/woff2',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Compress Unknown Content-Type
+    |--------------------------------------------------------------------------
+    |
+    | If the response does not include a Content-Type header, compression can
+    | still be applied. Disable this if your app streams binary payloads
+    | without setting explicit content types.
+    |
+    */
+    'compress_when_content_type_missing' => env('GZIP_COMPRESS_WHEN_CONTENT_TYPE_MISSING', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Middleware/GzipEncodeResponse.php
+++ b/src/Middleware/GzipEncodeResponse.php
@@ -12,14 +12,8 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 final class GzipEncodeResponse
 {
-    private array $config;
     private ?bool $hasBrotli = null;
     private ?bool $hasGzip = null;
-
-    public function __construct()
-    {
-        $this->config = config('laravel-gzip', []);
-    }
 
     /**
      * Handle an incoming request.
@@ -75,7 +69,7 @@ final class GzipEncodeResponse
                 ->noContent(Response::HTTP_NOT_MODIFIED)
                 ->withHeaders([
                     'ETag' => $etag,
-                    'Content-Encoding' => 'gzip',
+                    'Content-Encoding' => $encoding,
                     'Vary' => 'Accept-Encoding',
                 ]);
         }
@@ -187,6 +181,11 @@ final class GzipEncodeResponse
             return false;
         }
 
+        // Preserve byte ranges and partial content semantics
+        if ($response instanceof Response && ($response->headers->has('Content-Range') || $response->getStatusCode() === Response::HTTP_PARTIAL_CONTENT)) {
+            return false;
+        }
+
         // Don't compress when client sent Range requests (byte ranges)
         if ($request->headers->has('Range')) {
             return false;
@@ -220,8 +219,12 @@ final class GzipEncodeResponse
      */
     private function skipEnvironment(): bool
     {
-        $skipLocal = $this->config['skip_local'] ?? true;
-        $skipTesting = $this->config['skip_testing'] ?? true;
+        if ($this->shouldForceCompression()) {
+            return false;
+        }
+
+        $skipLocal = $this->getConfigValue('skip_local', true);
+        $skipTesting = $this->getConfigValue('skip_testing', true);
 
         if ($skipLocal && app()->isLocal()) {
             return true;
@@ -249,17 +252,7 @@ final class GzipEncodeResponse
      */
     private function clientSupportsCompression(Request $request): bool
     {
-        $acceptEncoding = $request->headers->get('Accept-Encoding', '');
-
-        // Check for Brotli support and gZip
-        if (
-            (str_contains($acceptEncoding, 'br') && $this->hasBrotliSupport()) ||
-            (str_contains($acceptEncoding, 'gzip') && $this->hasGzipSupport())
-        ) {
-            return true;
-        }
-
-        return false;
+        return $this->getBestEncoding($request) !== null;
     }
 
     /**
@@ -290,7 +283,7 @@ final class GzipEncodeResponse
      */
     private function isPathExcluded(Request $request): bool
     {
-        $excludedPaths = $this->config['excluded_paths'] ?? [];
+        $excludedPaths = $this->getConfigValue('excluded_paths', []);
         $currentPath = $request->path();
 
         if (empty($excludedPaths)) {
@@ -313,16 +306,16 @@ final class GzipEncodeResponse
     {
         $contentType = $response->headers->get('Content-Type', '');
         if (empty($contentType)) {
-            return false;
+            return $this->shouldCompressUnknownContentType();
         }
 
-        $nonCompressibleTypes = $this->config['excluded_mime_types'] ?? [];
+        $nonCompressibleTypes = $this->getConfigValue('excluded_mime_types', []);
         if (Str::startsWith($contentType, $nonCompressibleTypes)) {
             return false;
         }
 
         // Only compress known compressible types
-        $compressibleTypes = $this->config['compressible_mime_types'] ?? $this->getDefaultCompressibleTypes();
+        $compressibleTypes = $this->getConfigValue('compressible_mime_types', $this->getDefaultCompressibleTypes());
 
         return $this->matchesMimeType($contentType, $compressibleTypes);
     }
@@ -395,7 +388,7 @@ final class GzipEncodeResponse
         }
 
         $ratio = $compressedSize / $originalSize;
-        $minRatio = $this->config['minimum_compression_ratio'] ?? 0.95;
+        $minRatio = $this->getConfigValue('minimum_compression_ratio', 0.95);
 
         return $ratio < $minRatio;
     }
@@ -428,12 +421,12 @@ final class GzipEncodeResponse
      */
     private function shouldGzipResponse(): bool
     {
-        return (bool) ($this->config['enabled'] ?? true);
+        return (bool) ($this->getConfigValue('enabled', true));
     }
 
     protected function minimumContentLength(): int
     {
-        return (int) ($this->config['minimum_content_length'] ?? 1024);
+        return (int) ($this->getConfigValue('minimum_content_length', 1024));
     }
 
     /**
@@ -442,8 +435,18 @@ final class GzipEncodeResponse
      */
     private function compressLevel(): int
     {
-        $level = (int) ($this->config['level'] ?? 5);
+        $level = (int) ($this->getConfigValue('level', 6));
         return max(1, min(9, $level));
+    }
+
+    private function shouldForceCompression(): bool
+    {
+        return (bool) ($this->getConfigValue('force', false));
+    }
+
+    private function shouldCompressUnknownContentType(): bool
+    {
+        return (bool) ($this->getConfigValue('compress_when_content_type_missing', true));
     }
 
     /**
@@ -451,17 +454,17 @@ final class GzipEncodeResponse
      */
     private function shouldLog(): bool
     {
-        return (bool) ($this->config['log'] ?? false);
+        return (bool) ($this->getConfigValue('log', false));
     }
 
     private function shouldSetCacheControl(): bool
     {
-        return (bool) ($this->config['set_cache_control'] ?? false);
+        return (bool) ($this->getConfigValue('set_cache_control', false));
     }
 
     private function cacheControlMaxAge(): int
     {
-        return (int) ($this->config['cache_max_age'] ?? 86400);
+        return (int) ($this->getConfigValue('cache_max_age', 86400));
     }
 
     /**
@@ -472,23 +475,91 @@ final class GzipEncodeResponse
      */
     private function gzipDebugEnabled(): bool
     {
-        return (bool) ($this->config['debug'] ?? false);
+        return (bool) ($this->getConfigValue('debug', false));
     }
 
     private function getBestEncoding(Request $request): ?string
     {
-        $acceptEncoding = $request->headers->get('Accept-Encoding', '');
+        $acceptedEncodings = $this->parseAcceptEncoding($request);
 
-        // Prefer Brotli over Gzip if supported
-        if (str_contains($acceptEncoding, 'br') && $this->hasBrotliSupport()) {
-            return 'br';
-        }
+        foreach ($acceptedEncodings as $encoding) {
+            if ($encoding === 'br' && $this->hasBrotliSupport()) {
+                return 'br';
+            }
 
-        if (str_contains($acceptEncoding, 'gzip') && $this->hasGzipSupport()) {
-            return 'gzip';
+            if ($encoding === 'gzip' && $this->hasGzipSupport()) {
+                return 'gzip';
+            }
+
+            if ($encoding === '*' && $this->hasBrotliSupport()) {
+                return 'br';
+            }
+
+            if ($encoding === '*' && $this->hasGzipSupport()) {
+                return 'gzip';
+            }
         }
 
         return null;
+    }
+
+    /**
+     * Parse and sort Accept-Encoding values by quality (q) and our preference.
+     *
+     * @return array<int, string>
+     */
+    private function parseAcceptEncoding(Request $request): array
+    {
+        $header = strtolower($request->headers->get('Accept-Encoding', ''));
+
+        if ($header === '') {
+            return [];
+        }
+
+        $encodings = [];
+
+        foreach (explode(',', $header) as $part) {
+            $segments = array_map('trim', explode(';', trim($part)));
+            $encoding = $segments[0] ?? '';
+            if ($encoding === '') {
+                continue;
+            }
+
+            $quality = 1.0;
+            foreach (array_slice($segments, 1) as $parameter) {
+                if (str_starts_with($parameter, 'q=')) {
+                    $quality = (float) substr($parameter, 2);
+                    break;
+                }
+            }
+
+            if ($quality <= 0) {
+                continue;
+            }
+
+            $encodings[] = [
+                'encoding' => $encoding,
+                'q' => $quality,
+                'priority' => match ($encoding) {
+                    'br' => 2,
+                    'gzip' => 1,
+                    '*' => 0,
+                    default => -1,
+                },
+            ];
+        }
+
+        usort($encodings, static fn (array $left, array $right): int =>
+            ($right['q'] <=> $left['q'])
+            ?: ($right['priority'] <=> $left['priority'])
+        );
+
+        return array_values(array_unique(array_column($encodings, 'encoding')));
+    }
+
+    private function getConfigValue(string $key, mixed $default = null): mixed
+    {
+        return config("laravel-gzip.$key", $default);
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Users reported the middleware did not activate compression on newer Laravel (v11/12) setups, likely due to stale config, strict content-type checks, and incomplete Accept-Encoding negotiation.
- The goal was to make the package select the best supported encoding, avoid unsafe compression cases (ranges/partial responses), and make configuration flexible and easy to use.

### Description

- Implemented full Accept-Encoding parsing with `q=` quality handling and preference for `br` over `gzip`, via `parseAcceptEncoding()` and updated selection in `getBestEncoding()`.
- Switched all config reads to runtime via `getConfigValue()` (removed constructor-cached config) and added new options `force` and `compress_when_content_type_missing` to control skipping and missing Content-Type behavior.
- Fixed `304 Not Modified` responses to include the actual chosen `Content-Encoding`, prevented compression of partial/ranged responses (`Content-Range` / HTTP 206) and preserved `Vary: Accept-Encoding` handling.
- Tuned sensible defaults in `config/laravel-gzip.php`: default compression `level` 6, `minimum_content_length` 256, and `skip_local` default changed to `false`, plus config additions and README troubleshooting updates (clear config cache, `GZIP_FORCE` usage).

### Testing

- Ran PHP syntax checks: `php -l src/Middleware/GzipEncodeResponse.php`, `php -l config/laravel-gzip.php`, and `php -l src/GzipServiceProvider.php`, all succeeded.
- Ran `composer validate --no-check-publish`, which succeeded and confirmed `composer.json` is valid.
- Attempted `composer install` and `composer test`, but dependency installation and tests were blocked by network/proxy restrictions to Packagist (curl error 403), so automated PHPUnit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07aca5300832995b6d51c0d539ca6)